### PR TITLE
Make action fully equivalent to the okteto build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ When repository does not have an Okteto Manifest or `Dockerfile` is provided at 
 
 A list of comma-separated build arguments.
 
+### `no-cache`
+
+Set to "true" when no cache should be used when building the image
+
+### `cache-from`
+
+A list of comma-separated images from cache should be imported.
+
+### `export-cache`
+
+A list of comma-separated images where cache should be exported.
+
+### `secrets`
+
+A list of semi-colon secrets. Each with format: id=mysecret,src=/local/secret
+
 ## Example usage
 
 ### Build and push images for all services described at an Okteto Manifest

--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ You can use this action to build images from an [Okteto Manifest](https://www.ok
 The path to the Okteto Manifest. Default `"okteto.yml"`.
 Name of the Dockerfile. Default `"Dockerfile"`.
 
-### `global`
-
-When true will make the image available to everyone in your team. Default `false`.
-Only admins can push images to the global registry.
-
-
 ## Example usage
 
 This example runs the context action and then builds and pushes an image.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Service from the Okteto Manifest to build. You can select the service to build p
 
 When repository does not have an Okteto Manifest of `Dockerfile` is provided at `file`, `path` determines the context where the build should run.
 
+### `buildargs`
+
+A list of comma-separated build arguments.
+
 ## Example usage
 
 ### Build and push images for all services described at an Okteto Manifest

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ You can use this action to build images from an [Okteto Manifest](https://www.ok
 
 ### `file`
 
-The path to the Okteto Manifest. Default `"okteto.yml"`.
-Name of the Dockerfile. Default `"Dockerfile"`.
+The path to the Okteto Manifest or name of the Dockerfile.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Name and optionally a tag in the `name:tag` format for the build. When `file` po
 
 ### `file`
 
-Path to the Okteto Manifest. If no `file` is provided, `okteto build` will lookup for the Okteto Manifest file.
+The relative path to the Okteto Manifest.
 
-You can also use the `file` to point to a `Dockerfile`. In this mode, `okteto build` will ignore your Okteto Manifest, and directly build the image defined in the `Dockerfile`. Use this to build images that are not defined on your Okteto Manifest.
+> You can also use this input to point to a Dockerfile. In this mode, okteto build will ignore your Okteto manifest, and directly build the image defined in the Dockerfile. Use this to build images that are not defined on your Okteto manifest.
 
 ### `path`
 
 Service from the Okteto Manifest to build. You can select the service to build providing the `path`, otherwise all images at the Okteto Manifest build definition would be build.
 
-When repository does not have an Okteto Manifest of `Dockerfile` is provided at `file`, `path` determines the context where the build should run.
+When repository does not have an Okteto Manifest or `Dockerfile` is provided at `file`, `path` is the execution path of the action. .
 
 ### `buildargs`
 
@@ -83,7 +83,7 @@ jobs:
 
 ### Build and push images that are not defined on your Okteto manifest.
 
-This example runs the context action `okteto/context@latest` and then builds and pushes the image for a Dockerfile not included at the Okteto Manifest.
+This example sets the context, and then builds an image that is not defined in the Okteto Manifest.
 
 ```yaml
 # File: .github/workflows/workflow.yml
@@ -103,9 +103,9 @@ jobs:
       - name: "Build"
         uses: okteto/build@latest
         with:
-          tag: myapp:latest
+          tag: myapp-backend:latest
           file: Dockerfile
-          path: "."
+          path: backend
 ```
 
 If `tag` is not provided, the image won't be pushed to the registry.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ When using Okteto Manifest for the build, the tag is inferred or used from the M
 
 The path to the Okteto Manifest or name of the Dockerfile.
 
+### `path`
+
+The path where the build is run. 
+For repositories with Okteto Manifest, path represents the service of the Manifest to be built. Context is defined in the manifest.
+
+For repositories with Dockerfile, path represents the directory where the build should be run.
+
 ## Example usage
 
 This example runs the context action and then builds and pushes an image.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ You can use this action to build images from an [Okteto Manifest](https://www.ok
 
 ## Inputs
 
+### `tag`
+
+The image tag used for the build.
+
+If `Dockerfile` is provided as `file` argument and no `tag` is provided, the image won't be pushed to the registry after the build.
+
+When using Okteto Manifest for the build, the tag is inferred or used from the Manifest.
+
 ### `file`
 
 The path to the Okteto Manifest or name of the Dockerfile.

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Set to "true" when no cache should be used when building the image
 
 ### `cache-from`
 
-A list of comma-separated images from cache should be imported.
+A list of comma-separated images where cache should be imported from.
 
 ### `export-cache`
 
-A list of comma-separated images where cache should be exported.
+A list of comma-separated images where cache should be exported to.
 
 ### `secrets`
 
@@ -72,7 +72,7 @@ jobs:
         uses: okteto/build@latest
 ```
 
-### Build and push images for single service described at an Okteto Manifest
+### Build and push images for single service described in the Okteto Manifest
 
 This example runs the context action `okteto/context@latest` and then builds and pushes the image for the service `service`. A valid Okteto Manifest should exist at the repository.
 
@@ -97,7 +97,7 @@ jobs:
           path: service
 ```
 
-### Build and push images that are not defined on your Okteto manifest.
+### Build and push images that are not defined in your Okteto manifest.
 
 This example sets the context, and then builds an image that is not defined in the Okteto Manifest.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GitHub Actions for Okteto Cloud
 
 ## Automate your development workflows using Github Actions and Okteto Cloud
+
 GitHub Actions gives you the flexibility to build an automated software development workflows. With GitHub Actions for Okteto Cloud you can create workflows to build, deploy and update your applications in [Okteto Cloud](https://cloud.okteto.com).
 
 Get started today with a [free Okteto Cloud account](https://cloud.okteto.com)!
@@ -13,26 +14,25 @@ You can use this action to build images from an [Okteto Manifest](https://www.ok
 
 ### `tag`
 
-The image tag used for the build.
-
-If `Dockerfile` is provided as `file` argument and no `tag` is provided, the image won't be pushed to the registry after the build.
-
-When using Okteto Manifest for the build, the tag is inferred or used from the Manifest.
+Name and optionally a tag in the `name:tag` format for the build. When `file` points to a `Dockerfile`, in order to push the image to a registry, a `tag` is required. Otherwise, the build would be done but no image will be pushed to the registry.
 
 ### `file`
 
-The path to the Okteto Manifest or name of the Dockerfile.
+Path to the Okteto Manifest. If no `file` is provided, `okteto build` will lookup for the Okteto Manifest file.
+
+You can also use the `file` to point to a `Dockerfile`. In this mode, `okteto build` will ignore your Okteto Manifest, and directly build the image defined in the `Dockerfile`. Use this to build images that are not defined on your Okteto Manifest.
 
 ### `path`
 
-The path where the build is run. 
-For repositories with Okteto Manifest, path represents the service of the Manifest to be built. Context is defined in the manifest.
+Service from the Okteto Manifest to build. You can select the service to build providing the `path`, otherwise all images at the Okteto Manifest build definition would be build.
 
-For repositories with Dockerfile, path represents the directory where the build should be run.
+When repository does not have an Okteto Manifest of `Dockerfile` is provided at `file`, `path` determines the context where the build should run.
 
 ## Example usage
 
-This example runs the context action and then builds and pushes an image.
+### Build and push images for all services described at an Okteto Manifest
+
+This example runs the context action `okteto/context@latest` and then builds and pushes an image. A valid Okteto Manifest should exist at the repository.
 
 ```yaml
 # File: .github/workflows/workflow.yml
@@ -41,48 +41,99 @@ on: [push]
 name: example
 
 jobs:
-
   devflow:
     runs-on: ubuntu-latest
     steps:
-    
-    - uses: okteto/context@latest
-      with:
-        token: ${{ secrets.OKTETO_TOKEN }}
-    
-    - name: "Build"
-      uses: okteto/build@latest
+      - uses: okteto/context@latest
+        with:
+          token: ${{ secrets.OKTETO_TOKEN }}
+
+      - name: "Build"
+        uses: okteto/build@latest
 ```
+
+### Build and push images for single service described at an Okteto Manifest
+
+This example runs the context action `okteto/context@latest` and then builds and pushes the image for the service `service`. A valid Okteto Manifest should exist at the repository.
+
+```yaml
+# File: .github/workflows/workflow.yml
+on: [push]
+
+name: example
+
+jobs:
+  devflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Context Setup"
+        uses: okteto/context@latest
+        with:
+          token: ${{ secrets.OKTETO_TOKEN }}
+
+      - name: "Build"
+        uses: okteto/build@latest
+        with:
+          path: service
+```
+
+### Build and push images that are not defined on your Okteto manifest.
+
+This example runs the context action `okteto/context@latest` and then builds and pushes the image for a Dockerfile not included at the Okteto Manifest.
+
+```yaml
+# File: .github/workflows/workflow.yml
+on: [push]
+
+name: example
+
+jobs:
+  devflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Context Setup"
+        uses: okteto/context@latest
+        with:
+          token: ${{ secrets.OKTETO_TOKEN }}
+
+      - name: "Build"
+        uses: okteto/build@latest
+        with:
+          tag: myapp:latest
+          file: Dockerfile
+          path: "."
+```
+
+If `tag` is not provided, the image won't be pushed to the registry.
 
 ## Advanced usage
 
- ### Custom Certification Authorities or Self-signed certificates
+### Custom Certification Authorities or Self-signed certificates
 
- You can specify a custom certificate authority or a self-signed certificate by setting the `OKTETO_CA_CERT` environment variable. When this variable is set, the action will install the certificate in the container, and then execute the action. 
+You can specify a custom certificate authority or a self-signed certificate by setting the `OKTETO_CA_CERT` environment variable. When this variable is set, the action will install the certificate in the container, and then execute the action.
 
- Use this option if you're using a private Certificate Authority or a self-signed certificate in your [Okteto Enterprise](http://okteto.com/enterprise) instance.  We recommend that you store the certificate as an [encrypted secret](https://docs.github.com/en/actions/reference/encrypted-secrets), and that you define the environment variable for the entire job, instead of doing it on every step.
+Use this option if you're using a private Certificate Authority or a self-signed certificate in your [Okteto Enterprise](http://okteto.com/enterprise) instance. We recommend that you store the certificate as an [encrypted secret](https://docs.github.com/en/actions/reference/encrypted-secrets), and that you define the environment variable for the entire job, instead of doing it on every step.
 
+```yaml
+# File: .github/workflows/workflow.yml
+on: [push]
 
- ```yaml
- # File: .github/workflows/workflow.yml
- on: [push]
+name: example
 
- name: example
+jobs:
+  devflow:
+    runs-on: ubuntu-latest
+    env:
+      OKTETO_CA_CERT: ${{ secrets.OKTETO_CA_CERT }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@master
 
- jobs:
-   devflow:
-     runs-on: ubuntu-latest
-     env:
-       OKTETO_CA_CERT: ${{ secrets.OKTETO_CA_CERT }}
-     steps:
+    - name: "Context Setup"
+      uses: okteto/context@latest
+      with:
+        token: ${{ secrets.OKTETO_TOKEN }}
 
-     - name: checkout
-       uses: actions/checkout@master
-       
-     - uses: okteto/context@latest
-       with:
-         token: ${{ secrets.OKTETO_TOKEN }}
-     
     - name: "Build"
       uses: okteto/build@latest
- ```
+```

--- a/action.yml
+++ b/action.yml
@@ -2,15 +2,14 @@ name: 'Okteto Build'
 description: 'Build an image from a Dockerfile using Okteto Cloud'
 inputs:
   tag:
-    description: 'Name and tag in the "name:tag" format'
+    description: 'Name and tag for the image in the "name:tag" format'
     required: false
   file:
-    description: 'Name of the Okteto Manifest or Dockerfile'
+    description: 'Name of the file for Okteto Manifest or Dockerfile.'
     required: false
   path:
-    description: 'The path'
+    description: 'Path where the build is run.'
     required: false
-    default: '.'
   buildargs:
     description: 'Use buildargs when you want to pass a list of environment variables as build-args'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,18 @@ inputs:
   buildargs:
     description: 'Use buildargs when you want to pass a list of environment variables as build-args'
     required: false
+  no-cache:
+    description: 'Do not use cache when building the image'
+    required: false
+  cache-from:
+    description: 'List of cache source images'
+    required: false
+  export-cache:
+    description: 'List of exported cache images'
+    required: false
+  secrets:
+    description: 'Secret files exposed to the build. Format: id=mysecret,src=/local/secret'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -21,6 +33,11 @@ runs:
     - ${{ inputs.file }}
     - ${{ inputs.path }}
     - ${{ inputs.buildargs }}
+    - ${{ inputs.no-cache }}
+    - ${{ inputs.cache-from }}
+    - ${{ inputs.export-cache }}
+    - ${{ inputs.secrets }}
+
 branding:
   color: 'green'
   icon: 'layers'

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,6 @@ inputs:
   buildargs:
     description: 'Use buildargs when you want to pass a list of environment variables as build-args'
     required: false
-  global:
-    description: 'Use global when you want to make the image availbale to everyone in your team'
-    required: false
-    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -27,7 +23,6 @@ runs:
     - ${{ inputs.file }}
     - ${{ inputs.path }}
     - ${{ inputs.buildargs }}
-    - ${{ inputs.global }}
 branding:
   color: 'green'
   icon: 'layers'

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'Name and tag for the image in the "name:tag" format'
     required: false
   file:
-    description: 'Name of the file for Okteto Manifest or Dockerfile.'
+    description: 'Name of the file for the Okteto Manifest or Dockerfile.'
     required: false
   path:
     description: 'Path where the build is run.'

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,8 @@ inputs:
     description: 'Name and tag in the "name:tag" format'
     required: false
   file:
-    description: 'Name of the Dockerfile (Default is "Dockerfile")'
+    description: 'Name of the Okteto Manifest or Dockerfile'
     required: false
-    default: 'Dockerfile'
   path:
     description: 'The path'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 
+tag=$1
 file=$2
 
 BUILDPARAMS=""
@@ -12,6 +13,10 @@ if [ ! -z "$OKTETO_CA_CERT" ]; then
 fi
 
 params=$(eval echo --progress plain)
+
+if [ ! -z $tag ]; then
+   params=$(eval echo "$params" -t "$tag")
+fi
 
 if [ ! -z $file ]; then
    params=$(eval echo "$params" -f "$file")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,8 +35,9 @@ if [ ! -z $file ]; then
 fi
 
 if [ ! -z $buildargs ]; then
-   IFS=',' ;for i in $buildargs; do 
-      params="${params} --build-arg=${i}"
+   IFS=',' read -ra ARG <<< "$buildargs"
+   for i in "${ARG[@]}"; do 
+      params=$(eval echo "$params" --build-arg "$i")
    done
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,13 +3,24 @@ set -e
 
 tag=$1
 file=$2
-
-BUILDPARAMS=""
+path=$3
 
 if [ ! -z "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"
    echo "$OKTETO_CA_CERT" > /usr/local/share/ca-certificates/okteto_ca_cert.crt
    update-ca-certificates
+fi
+
+# if path is ".", override value to empty
+# Okteto CLI will run on root
+if [ "$path" = "." ]; then
+   path=""
+fi
+
+command="build"
+
+if [ ! -z $path ]; then
+   command=$(eval echo "$command" "$path")
 fi
 
 params=$(eval echo --progress plain)
@@ -22,8 +33,5 @@ if [ ! -z $file ]; then
    params=$(eval echo "$params" -f "$file")
 fi
 
-
-params=$(eval echo "$params")
-
-echo running: okteto build $params
-okteto build $params
+echo running: okteto $command $params
+okteto $command $params

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,12 @@ if [ ! -z "$OKTETO_CA_CERT" ]; then
    update-ca-certificates
 fi
 
-params=$(eval echo --progress plain -f "$file")
+params=$(eval echo --progress plain)
+
+if [ ! -z $file ]; then
+   params=$(eval echo "$params" -f "$file")
+fi
+
 
 params=$(eval echo "$params")
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,10 @@ tag=$1
 file=$2
 path=$3
 buildargs=$4
+nocache=$5
+cachefrom=$6
+exportcache=$7
+secrets=$8
 
 if [ ! -z "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"
@@ -38,6 +42,31 @@ if [ ! -z $buildargs ]; then
    IFS=',' read -ra ARG <<< "$buildargs"
    for i in "${ARG[@]}"; do 
       params=$(eval echo "$params" --build-arg "$i")
+   done
+fi
+
+if [ "$nocache" = "true" ]; then
+   params="${params} --no-cache"
+fi
+
+if [ ! -z $cachefrom ]; then
+   IFS=',' read -ra CACHEF <<< "$cachefrom"
+   for i in "${CACHEF[@]}"; do 
+      params=$(eval echo "$params" --cache-from "$i")
+   done
+fi
+
+if [ ! -z $exportcache ]; then
+   IFS=',' read -ra ECACHE <<< "$exportcache"
+   for i in "${ECACHE[@]}"; do 
+      params=$(eval echo "$params" --export-cache "$i")
+   done
+fi
+
+if [ ! -z $secrets ]; then
+   IFS=';' read -ra SECRET <<< "$secrets"
+   for i in "${SECRET[@]}"; do 
+      params=$(eval echo "$params" --secret "$i")
    done
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,6 @@
 set -e
 
 file=$2
-global=$5
 
 BUILDPARAMS=""
 
@@ -13,10 +12,6 @@ if [ ! -z "$OKTETO_CA_CERT" ]; then
 fi
 
 params=$(eval echo --progress plain -f "$file")
-
-if [ "$global" = "true" ]; then
-    params="${params} --global"
-fi
 
 params=$(eval echo "$params")
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 tag=$1
 file=$2
 path=$3
+buildargs=$4
 
 if [ ! -z "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"
@@ -31,6 +32,12 @@ fi
 
 if [ ! -z $file ]; then
    params=$(eval echo "$params" -f "$file")
+fi
+
+if [ ! -z $buildargs ]; then
+   IFS=',' ;for i in $buildargs; do 
+      params="${params} --build-arg=${i}"
+   done
 fi
 
 echo running: okteto $command $params


### PR DESCRIPTION
Resolves https://github.com/okteto/app/issues/6884

In order to make the action fully equivalent to the okteto build command here are the following changes:

- recover at `entrypoint.sh` the inputs documented at `action.yml`: `tag`,`path` and `buildargs`
- remove unused `global` from both `entrypoint.sh` and `action.yml`. Users can push to global registry by specific tag.
- include additional options `no-cache`, `cache-from`, `export-cache`, `secret` to be able to used them at the action
- review Readme and add more examples of use

**Tests done**

Used repository https://github.com/okteto/go-getting-started and https://github.com/okteto/movies-with-helm to have both monorepo and single repo

As entrypoint.sh is a script, locally simulating the input from the action with running the script with arguments

- Build single service not included at Okteto Manifest  `./entrypoint.sh "myapp:dev" "Dockerfile" "."`
- Build single service included at Okteto Manifest  `./entrypoint.sh "" "" "myapp"`
- Build all services included at Okteto Manifest  `./entrypoint.sh "" "" ""`



