### PR TITLE
Fix shell sintax

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ cachefrom=$6
 exportcache=$7
 secrets=$8
 
-if [ ! -z "$OKTETO_CA_CERT" ]; then
+if [ -n "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"
    echo "$OKTETO_CA_CERT" > /usr/local/share/ca-certificates/okteto_ca_cert.crt
    update-ca-certificates
@@ -24,51 +24,72 @@ fi
 
 command="build"
 
-if [ ! -z $path ]; then
+if [ -n "$path" ]; then
    command=$(eval echo "$command" "$path")
 fi
 
 params=$(eval echo --progress plain)
 
-if [ ! -z $tag ]; then
+if [ -n "$tag" ]; then
    params=$(eval echo "$params" -t "$tag")
 fi
 
-if [ ! -z $file ]; then
+if [ -n "$file" ]; then
    params=$(eval echo "$params" -f "$file")
 fi
 
-if [ ! -z $buildargs ]; then
-   IFS=',' read -ra ARG <<< "$buildargs"
-   for i in "${ARG[@]}"; do 
-      params=$(eval echo "$params" --build-arg "$i")
+if [ -n "$buildargs" ]; then
+   IFS=',' 
+   # shellcheck disable=SC2086
+   set -- $buildargs
+   unset IFS
+
+   while [ $# -gt 0 ]; do
+      params=$(eval echo "$params" --build-arg "$1")
+      shift
    done
 fi
 
 if [ "$nocache" = "true" ]; then
-   params="${params} --no-cache"
+      params=$(eval echo "$params" --no-cache)
 fi
 
-if [ ! -z $cachefrom ]; then
-   IFS=',' read -ra CACHEF <<< "$cachefrom"
-   for i in "${CACHEF[@]}"; do 
-      params=$(eval echo "$params" --cache-from "$i")
+if [ -n "$cachefrom" ]; then
+   IFS=','
+   # shellcheck disable=SC2086
+   set -- $cachefrom
+   unset IFS
+
+   while [ $# -gt 0 ]; do
+      params=$(eval echo "$params" --cache-from "$1")
+      shift
    done
 fi
 
-if [ ! -z $exportcache ]; then
-   IFS=',' read -ra ECACHE <<< "$exportcache"
-   for i in "${ECACHE[@]}"; do 
-      params=$(eval echo "$params" --export-cache "$i")
+if [ -n "$exportcache" ]; then
+   IFS=','
+   # shellcheck disable=SC2086
+   set -- $cachefrom
+   unset IFS
+
+   while [ $# -gt 0 ]; do
+      params=$(eval echo "$params" --export-cache "$1")
+      shift
    done
 fi
 
-if [ ! -z $secrets ]; then
-   IFS=';' read -ra SECRET <<< "$secrets"
-   for i in "${SECRET[@]}"; do 
-      params=$(eval echo "$params" --secret "$i")
+if [ -n "$secrets" ]; then
+   IFS=';'
+   # shellcheck disable=SC2086
+   set -- $secrets
+   unset IFS
+
+   while [ $# -gt 0 ]; do
+      params=$(eval echo "$params" --secret "$1")
+      shift
    done
 fi
 
-echo running: okteto $command $params
+echo running: okteto "$command" "$params"
+# shellcheck disable=SC2086
 okteto $command $params

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,7 +69,7 @@ fi
 if [ -n "$exportcache" ]; then
    IFS=','
    # shellcheck disable=SC2086
-   set -- $cachefrom
+   set -- $exportcache
    unset IFS
 
    while [ $# -gt 0 ]; do


### PR DESCRIPTION
The changes at the shell script syntax were not compliant so when running the script at CI there was an error regarding Syntax.

This PR fixes the syntax errors.


- Updated the script using linting `shellcheck` to make it compliant with POSX https://www.shellcheck.net/
- Running Okteto CLI integration tests using the branch to verify the script is running under CI checks
  - https://app.circleci.com/pipelines/github/okteto/okteto/11713/workflows/a27620eb-345a-4c53-a7fd-4fa7eaf6c25c/jobs/38061?invite=true#step-107-3807_33
  - https://github.com/okteto/okteto/blob/tere/fix-action-test_e2e/integration/actions/build_test.go#L63
- Running action agains this branch https://github.com/teresaromero/go-getting-started/actions with different params