### PR TITLE
Support "platform" in the Okteto Build action

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A list of comma-separated images where cache should be exported to.
 
 A list of semi-colon secrets. Each with format: id=mysecret,src=/local/secret
 
-### `plaform`
+### `platform`
 
 A list of semi-colon target platforms to build
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ A list of comma-separated images where cache should be exported to.
 
 A list of semi-colon secrets. Each with format: id=mysecret,src=/local/secret
 
+### `plaform`
+
+A list of semi-colon target platforms to build
+
 ## Example usage
 
 ### Build and push images for all services described at an Okteto Manifest

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   secrets:
     description: 'Secret files exposed to the build. Format: id=mysecret,src=/local/secret'
     required: false
+  platform:
+    description: 'Set target platform for build'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -37,6 +40,7 @@ runs:
     - ${{ inputs.cache-from }}
     - ${{ inputs.export-cache }}
     - ${{ inputs.secrets }}
+    - ${{ inputs.platform }}
 
 branding:
   color: 'green'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ if [ -n "$file" ]; then
 fi
 
 if [ -n "$buildargs" ]; then
-   IFS=',' 
+   IFS=','
    # shellcheck disable=SC2086
    set -- $buildargs
    unset IFS
@@ -89,6 +89,11 @@ if [ -n "$secrets" ]; then
       shift
    done
 fi
+
+if [ -n "$platform" ]; then
+   params=$(eval echo "$params" --platform "$platform")
+fi
+
 
 echo running: okteto "$command" "$params"
 # shellcheck disable=SC2086

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,7 @@ nocache=$5
 cachefrom=$6
 exportcache=$7
 secrets=$8
+platform=$9
 
 if [ -n "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"


### PR DESCRIPTION
`platform` is supported by the Okteto CLI but not by the build action.
Adding support for it