### PR TITLE
Add log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ A list of semi-colon secrets. Each with format: id=mysecret,src=/local/secret
 
 A list of semi-colon target platforms to build
 
+### `log-level`
+
+Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to warn)
+
 ## Example usage
 
 ### Build and push images for all services described at an Okteto Manifest

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   platform:
     description: 'Set target platform for build'
     required: false
+  log-level:
+    description: "Log level string. Valid options are debug, info, warn, error"
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -41,6 +44,7 @@ runs:
     - ${{ inputs.export-cache }}
     - ${{ inputs.secrets }}
     - ${{ inputs.platform }}
+    - ${{ inputs.log-level }}  
 
 branding:
   color: 'green'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,7 +95,24 @@ if [ -n "$platform" ]; then
    params=$(eval echo "$params" --platform "$platform")
 fi
 
+log_level=$10
 
-echo running: okteto "$command" "$params"
+if [ ! -z "$log_level" ]; then
+  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
+    log_level="--log-level ${log_level}"
+  else
+    echo "log-level supported: debug, info, warn, error"
+    exit 1
+  fi
+fi
+
+# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+if [ "${RUNNER_DEBUG}" = "1" ]; then
+  log_level="--log-level debug"
+fi
+
+
+echo running: okteto "$command" "$params" $log_level
 # shellcheck disable=SC2086
-okteto $command $params
+okteto $command $params $log_level

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -101,7 +101,7 @@ if [ ! -z "$log_level" ]; then
   if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
     log_level="--log-level ${log_level}"
   else
-    echo "log-level supported: debug, info, warn, error"
+    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
     exit 1
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,7 +95,7 @@ if [ -n "$platform" ]; then
    params=$(eval echo "$params" --platform "$platform")
 fi
 
-log_level=$10
+log_level=${10}
 
 if [ ! -z "$log_level" ]; then
   if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then


### PR DESCRIPTION
Resolves https://okteto.atlassian.net/browse/DEV-320

As done for deploy-preview this PR adds the input of log-level to the action in order to enable debug logging or any other level the user wants to use on the runs.

Tested running the pipeline using the last commit
https://github.com/teresaromero/go-getting-started/actions/workflows/test-actions.yml